### PR TITLE
Remove unnecessary libm dependency from libflow

### DIFF
--- a/libflow/Makefile
+++ b/libflow/Makefile
@@ -16,7 +16,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/libflow
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libc +libpthread +libm +librt +libgnutls
+  DEPENDS:=+libc +libpthread +librt +libgnutls
   TITLE:=FlowCloud Core and Messaging Libraries by Imagination
 endef
 


### PR DESCRIPTION
It was giving error while opkg install, hence removing libm dependency without which too, everything works fine.
Signed-off-by: Abhijit Mahajani Abhijit.Mahajani@imgtec.com
